### PR TITLE
added hint with link to docs for bluetooth api support

### DIFF
--- a/src/components/printer/PrinterConnection.vue
+++ b/src/components/printer/PrinterConnection.vue
@@ -22,6 +22,11 @@
 		</div>
 
 	</div>
+
+	<a v-else class="no-support-text"
+	   href="https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth#browser_compatibility">
+		Oh no, browser not supported
+	</a>
 </template>
 
 <script setup lang="ts">
@@ -101,5 +106,11 @@ function removeImageEvent(index: number): void {
 
 .connected-printer {
 	position: relative;
+}
+
+.no-support-text {
+	/* letter-spacing: 1px; */
+	font-size: 16px;
+	color: var(--dynamic-bg-color)
 }
 </style>


### PR DESCRIPTION
As suggested by sturmen in #6 a small hint is placed where the "connect" button is usually with a hint stating "Oh no, browser not supported" and a link to the Bluetooth Web API Compatibility chart. For now this should clarify why the connect button is not shown.
<img width="1440" alt="Bildschirmfoto 2024-09-05 um 16 29 11" src="https://github.com/user-attachments/assets/5d06d9fd-3b84-4f25-9323-50ab9e9824c5">
